### PR TITLE
RecursiveDirectoryIterator don't obtain some order of the file list.

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
@@ -71,6 +71,8 @@ final class RecursiveRegexFinder extends AbstractFinder implements MigrationDeep
         foreach ($iteratorFilesMatch as $file) {
             $files[] = $file[0];
         }
+        
+        sort($files);
 
         return $files;
     }


### PR DESCRIPTION
RecursiveDirectoryIterator shouldn't return a sorted list and haven't to do it be direct. But migration script logic requires sorted list of the Version*.php files for correct working.
